### PR TITLE
Do not require `external_id`

### DIFF
--- a/app/concepts/bloom_remit/txns/contracts/create.rb
+++ b/app/concepts/bloom_remit/txns/contracts/create.rb
@@ -14,8 +14,6 @@ module BloomRemit
         property :owner_type
         property :external_id
 
-        validates :external_id, presence: true
-
       end
     end
   end

--- a/spec/concepts/bloom_remit/txns/contracts/create_spec.rb
+++ b/spec/concepts/bloom_remit/txns/contracts/create_spec.rb
@@ -7,7 +7,6 @@ module BloomRemit
 
         describe "validations" do
           subject { described_class.new(Txn.new) }
-          it { is_expected.to validate_presence_of(:external_id) }
         end
 
       end


### PR DESCRIPTION
As of now, the API does not require this. It will eventually
(but only as a way to mitigate double transactions from clients)
